### PR TITLE
[Refactor] PostListCell의 레이아웃의 개선

### DIFF
--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/PostListCell.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/PostListCell.swift
@@ -16,13 +16,12 @@ final class PostListCell: UITableViewCell, Reusable {
     
     let categoryLabel: UILabel = {
         let label = UILabel()
-
+        
         label.font = UIFont.et_pretendard(
             style: .bold,
             size: 14
         )
-
-        label.sizeToFit()
+        
         label.layer.cornerRadius = 4
         label.clipsToBounds = true
         
@@ -40,7 +39,7 @@ final class PostListCell: UITableViewCell, Reusable {
             style: .bold,
             size: 16
         )
-        label.sizeToFit()
+        
         return label
     }()
     
@@ -52,7 +51,6 @@ final class PostListCell: UITableViewCell, Reusable {
         )
         label.numberOfLines = 2
         label.textColor = .et_textColorBlack50
-        label.sizeToFit()
         
         return label
     }()
@@ -72,7 +70,6 @@ final class PostListCell: UITableViewCell, Reusable {
             style: .medium,
             size: 12
         )
-        label.sizeToFit()
         
         return label
     }()
@@ -101,7 +98,6 @@ final class PostListCell: UITableViewCell, Reusable {
             style: .medium,
             size: 12
         )
-        label.sizeToFit()
         
         return label
     }()
@@ -111,7 +107,6 @@ final class PostListCell: UITableViewCell, Reusable {
         stackView.axis = .horizontal
         stackView.spacing = 3
         stackView.distribution = .fill
-        stackView.sizeToFit()
         
         return stackView
     }()
@@ -131,7 +126,6 @@ final class PostListCell: UITableViewCell, Reusable {
             style: .medium,
             size: 12
         )
-        label.sizeToFit()
         
         return label
     }()
@@ -141,7 +135,6 @@ final class PostListCell: UITableViewCell, Reusable {
         stackView.axis = .horizontal
         stackView.spacing = 3
         stackView.distribution = .fill
-        stackView.sizeToFit()
         
         return stackView
     }()
@@ -167,7 +160,7 @@ final class PostListCell: UITableViewCell, Reusable {
     private func setupLayout() {
         titleLabel.addSubview(categoryLabel)
         contentView.addSubview(titleLabel)
-
+        
         contentView.addSubview(userStackView)
         userStackView.addArrangedSubview(userImageView)
         userStackView.addArrangedSubview(userNameLabel)
@@ -175,7 +168,7 @@ final class PostListCell: UITableViewCell, Reusable {
         contentView.addSubview(likeCountStackView)
         likeCountStackView.addArrangedSubview(likeCountImageView)
         likeCountStackView.addArrangedSubview(likeCountLabel)
-
+        
         contentView.addSubview(viewCountStackView)
         viewCountStackView.addArrangedSubview(viewCountImageView)
         viewCountStackView.addArrangedSubview(viewCountLabel)
@@ -189,7 +182,7 @@ final class PostListCell: UITableViewCell, Reusable {
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(contentView).offset(15)
             $0.leading.equalTo(contentView)
-            $0.trailing.equalTo(contentView).offset(-120)
+            $0.trailing.equalTo(thumbnailImageView.snp.leading).offset(-15)
         }
         
         categoryLabel.snp.makeConstraints {


### PR DESCRIPTION
## 이슈 번호: #24 

## PR 타입

- [ ] 기능 구현
- [x] 오류 수정
- [x] 리팩토링

<br>

### 작업 내용

> 구현 및 작업 내용을 작성합니다.

- 간헐적으로 고장나던 셀의 레이아웃을 수정했습니다.

[수정 전]
![image](https://github.com/user-attachments/assets/ed39c80f-89d6-47b8-b87b-d74d1a95249c)

[수정 후 iPhone 15 pro max]
![image](https://github.com/user-attachments/assets/2e15efdb-d739-4c95-9374-a6b86eef74b1)

[수정 후 iPhone SE 3]
![image](https://github.com/user-attachments/assets/ad5c0266-8268-42c6-8535-81645472fe1a)

<br>

### PR 체크리스트

- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항

> PR 리뷰 시 주의 깊게 보거나 유의해야 할 점들과 기타 사항을 작성합니다.

- 현재 이미지 뷰의 크기가 컨텐츠 뷰의 일정 비율에 맞춰져있고, 각 UI요소 간격등이 피그마 시안을 기준으로 작성되어
pro max 처럼 **큰 화면의 기기와 적은 양의 게시글이 만났을때 조금 어색해보이는 경향**이 있지만, 디자인팀과 추가적인 논의가 필요한 부분으로 보이며 기존 크게 잘못 된 부분을 잡아놔서 금방 처리가 가능할것으로 예상됩니다.

<br>
