### PR TITLE
[Feat] 이메일 인증코드 요청 및 검증 작업에 대한 Domain Layer 작업

### DIFF
--- a/EveryTip/Targets/EveryTipDomain/Sources/DomainAssembly.swift
+++ b/EveryTip/Targets/EveryTipDomain/Sources/DomainAssembly.swift
@@ -32,5 +32,10 @@ public struct DomainAssembly: Assembly {
         container.register(RequestTokenUseCase.self) { _ in
             DefaultRequestTokenUseCase(loginRepository: container.resolve(UserLoginRepository.self)!)
         }
+        
+        container.register(AuthUseCase.self) { _ in
+            DefaultAuthUseCase(
+                verificationCodeRepository: container.resolve(VerificationCodeRepository.self)!)
+        }
     }
 }

--- a/EveryTip/Targets/EveryTipDomain/Sources/Entities/Model/VerificationCodeResponse.swift
+++ b/EveryTip/Targets/EveryTipDomain/Sources/Entities/Model/VerificationCodeResponse.swift
@@ -1,0 +1,19 @@
+//
+//  VerificationCodeResponse.swift
+//  EveryTipDomain
+//
+//  Created by 김경록 on 2/17/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import Foundation
+
+public struct VerificationCodeResponse: Decodable {
+    public let code: String
+    public let message: String
+    
+    public init(code: String, message: String) {
+        self.code = code
+        self.message = message
+    }
+}

--- a/EveryTip/Targets/EveryTipDomain/Sources/Repositories/AgreementsRepository.swift
+++ b/EveryTip/Targets/EveryTipDomain/Sources/Repositories/AgreementsRepository.swift
@@ -13,8 +13,3 @@ import RxSwift
 public protocol AgreementsRepository {
     func fetchAgreements()
 }
-
-
-public protocol EmailRepository {
-    func requestEmailCode(with email: String)
-}

--- a/EveryTip/Targets/EveryTipDomain/Sources/Repositories/VerificationCodeRepository.swift
+++ b/EveryTip/Targets/EveryTipDomain/Sources/Repositories/VerificationCodeRepository.swift
@@ -1,0 +1,16 @@
+//
+//  VerificationCodeRepository.swift
+//  EveryTipDomain
+//
+//  Created by 김경록 on 3/12/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+public protocol VerificationCodeRepository {
+    func requestCode(with email: String) -> Single<VerificationCodeResponse>
+    func checkCode(with code: String) -> Single<Data>
+}

--- a/EveryTip/Targets/EveryTipDomain/Sources/UseCases/AuthUseCase/AuthUseCase.swift
+++ b/EveryTip/Targets/EveryTipDomain/Sources/UseCases/AuthUseCase/AuthUseCase.swift
@@ -16,3 +16,22 @@ public protocol AuthUseCase {
     func requestEmailCode(email: String) -> Single<VerificationCodeResponse>
     func checkEmailCode(code: String) -> Single<Data>
 }
+
+public final class DefaultAuthUseCase: AuthUseCase {
+    
+    private let verificationCodeRepository: VerificationCodeRepository
+    
+    init(
+        verificationCodeRepository: VerificationCodeRepository
+    ) {
+        self.verificationCodeRepository = verificationCodeRepository
+    }
+    
+    public func requestEmailCode(email: String) -> RxSwift.Single<VerificationCodeResponse> {
+        verificationCodeRepository.requestCode(with: email)
+    }
+    
+    public func checkEmailCode(code: String) -> RxSwift.Single<Data> {
+        verificationCodeRepository.checkCode(with: code)
+    }
+}

--- a/EveryTip/Targets/EveryTipDomain/Sources/UseCases/AuthUseCase/AuthUseCase.swift
+++ b/EveryTip/Targets/EveryTipDomain/Sources/UseCases/AuthUseCase/AuthUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  AuthUseCase.swift
+//  EveryTipDomain
+//
+//  Created by 김경록 on 2/20/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import RxSwift
+
+import Foundation
+
+// TODO: 각 Auth관련 UseCase 통합
+
+public protocol AuthUseCase {
+    func requestEmailCode(email: String) -> Single<VerificationCodeResponse>
+    func checkEmailCode(code: String) -> Single<Data>
+}


### PR DESCRIPTION
## 이슈 번호: #

## PR 타입

- [x] 기능 구현
- [ ] 오류 수정
- [ ] 리팩토링

<br>

### 작업 내용

> 구현 및 작업 내용을 작성합니다.
1. UseCase를 비즈니스 로직별로 병합하였습니다.
기존 병합을 예정에만 두고 보류했었는데 화면별로 묶는것, 각 비즈니니스 로직마다 묶는것 중 고민하다
각 큰 비즈니스로직 마다 묶어서 진행하는게 좋다고 판단되었습니다. 화면별로 묶는것이 개발 속도에선 이점이 있을것으로 예상했으나,
각 유즈케이스가 가지는 책임의 단일성이 다소 떨어진다 생각하여 비지니스 로직별로 병합하였습니다.
현재 예상 분류는

- Auth (전반적 인증 작업 및 회원가입 포함)
- User ( 팔로잉 시스템 및 유저 정보 관리 전반)
- Posting ( 게시글 작성 및 댓글작성등)
정도로 예상하고 있습니다. 조금 더 세분화가 필요할 지 코멘트 부탁드립니다.
이번 PR에서 회원가입과정에서의 이메일 인증과 이메일 코드 확인 등이 Auth에 포함되었습니다.
추후 다른 Usecase도 관련 작업시에 순차적으로 병합 할 예정입니다.

<br>

### PR 체크리스트

- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항

> PR 리뷰 시 주의 깊게 보거나 유의해야 할 점들과 기타 사항을 작성합니다.
<br>

- CheckCode 시에는 디코딩을 수행하지 않으므로 DTO를 별도로 정의하지 않았습니다.
다만, request의 경우 200번대 응답이 오더라도 실제 이메일이 존재하지 않는 등의 예외적인 상황을 처리할 필요가 있어 디코딩을 진행하도록 했습니다.