### PR TITLE
[Feat] 인증코드 관련 DataLayer 작업

### DIFF
--- a/EveryTip/Targets/EveryTipData/Sources/DataAssembly.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/DataAssembly.swift
@@ -35,5 +35,9 @@ public struct DataAssembly: Assembly {
         container.register(UserLoginRepository.self) { _ in
             return DefaultUserLoginRepository()
         }
+        
+        container.register(VerificationCodeRepository.self) { _ in
+            return DefaultVerificationCodeRepository()
+        }
     }
 }

--- a/EveryTip/Targets/EveryTipData/Sources/Repositories/DefaultVerificationCodeRepository.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Repositories/DefaultVerificationCodeRepository.swift
@@ -22,50 +22,50 @@ struct DefaultVerificationCodeRepository: VerificationCodeRepository {
     
     func requestCode(with email: String) -> Completable {
         Completable.create { completable in
-            do {
-                let request = try AuthTarget.postVerificaitonCode(email: email).asURLRequest()
-                let task = self.session?.request(request, interceptor: nil)
-                    .validate(statusCode: 200..<300)
-                    .responseDecodable(of: BaseResponseDTO.self) { response in
-                        switch response.result {
-                        case .success(let result):
-                            // 통신 자체는 성공했으나 이메일 사용 불가등의 경우로 API가 Code를 Fail로 반환하는 경우를 처리
-                            if result.code == "FAIL" {
-                                completable(.error(NetworkError.invalidEmail))
-                            }
-                            completable(.completed)
-                        case .failure(let error):
-                            completable(.error(error))
-                        }
-                    }
-                return Disposables.create { task?.cancel() }
-            } catch {
-                completable(.error(error))
+            guard let request = try? AuthTarget.postVerificationEmail(email: email).asURLRequest() else {
+                completable(.error(NetworkError.invalidURLError))
                 return Disposables.create()
             }
+            
+            let task = self.session?.request(request, interceptor: nil)
+                .validate(statusCode: 200..<300)
+                .responseDecodable(of: BaseResponseDTO.self) { response in
+                    switch response.result {
+                    case .success(let result):
+                        // 통신 자체는 성공했으나 이메일 사용 불가등의 경우로 API가 Code를 Fail로 반환하는 경우를 처리
+                        if result.code == "FAIL" {
+                            completable(.error(NetworkError.invalidEmail))
+                        }
+                        completable(.completed)
+                    case .failure(let error):
+                        completable(.error(error))
+                    }
+                }
+            return Disposables.create { task?.cancel() }
+            
         }
     }
     
     func checkCode(with code: String) -> Completable {
         Completable.create { completable in
-            do {
-                let request = try AuthTarget.getCheckVerificationCode(code: code).asURLRequest()
-                let task = self.session?.request(request, interceptor: nil)
-                    .validate(statusCode: 200..<300)
-                    .responseDecodable(of: BaseResponseDTO.self) { response in
-                        switch response.result {
-                        case .success(_):
-                            completable(.completed)
-                        case .failure(let error):
-                            completable(.error(error))
-                        }
-                    }
-                return Disposables.create { task?.cancel() }
-                
-            } catch {
-                completable(.error(error))
+            
+            guard let request = try? AuthTarget.getCheckVerificationCode(code: code).asURLRequest() else {
+                completable(.error(NetworkError.invalidURLError))
                 return Disposables.create()
             }
+            
+            let task = self.session?.request(request, interceptor: nil)
+                .validate(statusCode: 200..<300)
+                .responseDecodable(of: BaseResponseDTO.self) { response in
+                    switch response.result {
+                    case .success(_):
+                        completable(.completed)
+                    case .failure(let error):
+                        completable(.error(error))
+                    }
+                }
+            return Disposables.create { task?.cancel() }
+            
         }
     }
 }

--- a/EveryTip/Targets/EveryTipData/Sources/Repositories/DefaultVerificationCodeRepository.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Repositories/DefaultVerificationCodeRepository.swift
@@ -32,11 +32,9 @@ struct DefaultVerificationCodeRepository: VerificationCodeRepository {
                 .responseDecodable(of: BaseResponseDTO.self) { response in
                     switch response.result {
                     case .success(let result):
-                        // 통신 자체는 성공했으나 이메일 사용 불가등의 경우로 API가 Code를 Fail로 반환하는 경우를 처리
-                        if result.code == "FAIL" {
-                            completable(.error(NetworkError.invalidEmail))
+                        if result.code == "SUCCESS" {
+                            completable(.completed)
                         }
-                        completable(.completed)
                     case .failure(let error):
                         completable(.error(error))
                     }

--- a/EveryTip/Targets/EveryTipData/Sources/Repositories/DefaultVerificationCodeRepository.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Repositories/DefaultVerificationCodeRepository.swift
@@ -1,0 +1,71 @@
+//
+//  DefaultVerificationCodeRepository.swift
+//  EveryTipData
+//
+//  Created by 김경록 on 3/14/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import Foundation
+
+import EveryTipDomain
+
+import Alamofire
+import RxSwift
+
+struct DefaultVerificationCodeRepository: VerificationCodeRepository {
+    let session: Session?
+    
+    init(session: Session? = .default) {
+        self.session = session
+    }
+    
+    func requestCode(with email: String) -> Completable {
+        Completable.create { completable in
+            do {
+                let request = try AuthTarget.postVerificaitonCode(email: email).asURLRequest()
+                let task = self.session?.request(request, interceptor: nil)
+                    .validate(statusCode: 200..<300)
+                    .responseDecodable(of: BaseResponseDTO.self) { response in
+                        switch response.result {
+                        case .success(let result):
+                            // 통신 자체는 성공했으나 이메일 사용 불가등의 경우로 API가 Code를 Fail로 반환하는 경우를 처리
+                            if result.code == "FAIL" {
+                                completable(.error(NetworkError.invalidEmail))
+                            }
+                            completable(.completed)
+                        case .failure(let error):
+                            completable(.error(error))
+                        }
+                    }
+                return Disposables.create { task?.cancel() }
+            } catch {
+                completable(.error(error))
+                return Disposables.create()
+            }
+        }
+    }
+    
+    func checkCode(with code: String) -> Completable {
+        Completable.create { completable in
+            do {
+                let request = try AuthTarget.getCheckVerificationCode(code: code).asURLRequest()
+                let task = self.session?.request(request, interceptor: nil)
+                    .validate(statusCode: 200..<300)
+                    .responseDecodable(of: BaseResponseDTO.self) { response in
+                        switch response.result {
+                        case .success(_):
+                            completable(.completed)
+                        case .failure(let error):
+                            completable(.error(error))
+                        }
+                    }
+                return Disposables.create { task?.cancel() }
+                
+            } catch {
+                completable(.error(error))
+                return Disposables.create()
+            }
+        }
+    }
+}

--- a/EveryTip/Targets/EveryTipData/Sources/Repositories/DefaultVerificationCodeRepository.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Repositories/DefaultVerificationCodeRepository.swift
@@ -32,8 +32,10 @@ struct DefaultVerificationCodeRepository: VerificationCodeRepository {
                 .responseDecodable(of: BaseResponseDTO.self) { response in
                     switch response.result {
                     case .success(let result):
-                        if result.code == "SUCCESS" {
+                        if result.isSuccess() {
                             completable(.completed)
+                        } else {
+                            completable(.error(NetworkError.invalidEmail))
                         }
                     case .failure(let error):
                         completable(.error(error))

--- a/EveryTip/Targets/EveryTipData/Sources/Services/APIs/Auth/AuthTarget.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/APIs/Auth/AuthTarget.swift
@@ -39,8 +39,8 @@ extension AuthTarget: TargetType {
             return "/auth/sign-in"
         case .postVerificationEmail:
             return "/auth/verification/email"
-        case .getCheckVerificationCode(let code):
-            return "/auth/verification?code=\(code)"
+        case .getCheckVerificationCode:
+            return "/auth/verification"
         }
     }
     
@@ -52,8 +52,8 @@ extension AuthTarget: TargetType {
             return ["email": email, "password": password]
         case .postVerificationEmail(email: let email):
             return ["email": email]
-        case .getCheckVerificationCode:
-            return nil
+        case .getCheckVerificationCode(let code):
+            return ["code": code]
         }
     }
     

--- a/EveryTip/Targets/EveryTipData/Sources/Services/APIs/Auth/AuthTarget.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/APIs/Auth/AuthTarget.swift
@@ -13,7 +13,7 @@ import Alamofire
 enum AuthTarget {
     case getAgreements
     case postUserLogin(email: String, password: String)
-    case postVerificaitonCode(email: String)
+    case postVerificationEmail(email: String)
     case getCheckVerificationCode(code: String)
 }
 
@@ -24,7 +24,7 @@ extension AuthTarget: TargetType {
                 .get
         case .postUserLogin:
                 .post
-        case .postVerificaitonCode:
+        case .postVerificationEmail:
                 .post
         case .getCheckVerificationCode:
                 .get
@@ -37,7 +37,7 @@ extension AuthTarget: TargetType {
             return "/auth/agreements"
         case .postUserLogin:
             return "/auth/sign-in"
-        case .postVerificaitonCode:
+        case .postVerificationEmail:
             return "/auth/verification/email"
         case .getCheckVerificationCode(let code):
             return "/auth/verification?code=\(code)"
@@ -50,7 +50,7 @@ extension AuthTarget: TargetType {
             return nil
         case .postUserLogin(email: let email, password: let password):
             return ["email": email, "password": password]
-        case .postVerificaitonCode(email: let email):
+        case .postVerificationEmail(email: let email):
             return ["email": email]
         case .getCheckVerificationCode:
             return nil
@@ -63,7 +63,7 @@ extension AuthTarget: TargetType {
             return nil
         case .postUserLogin:
             return ["Content-Type": "application/json"]
-        case .postVerificaitonCode:
+        case .postVerificationEmail:
             return ["Content-Type": "application/json"]
         case .getCheckVerificationCode:
             return nil

--- a/EveryTip/Targets/EveryTipData/Sources/Services/APIs/Auth/AuthTarget.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/APIs/Auth/AuthTarget.swift
@@ -12,8 +12,9 @@ import Alamofire
 
 enum AuthTarget {
     case getAgreements
-    case postEmailCode(email: String)
     case postUserLogin(email: String, password: String)
+    case postVerificaitonCode(email: String)
+    case getCheckVerificationCode(code: String)
 }
 
 extension AuthTarget: TargetType {
@@ -21,10 +22,12 @@ extension AuthTarget: TargetType {
         switch self {
         case .getAgreements:
                 .get
-        case .postEmailCode:
-                .post
         case .postUserLogin:
                 .post
+        case .postVerificaitonCode:
+                .post
+        case .getCheckVerificationCode:
+                .get
         }
     }
     
@@ -32,10 +35,12 @@ extension AuthTarget: TargetType {
         switch self {
         case .getAgreements:
             return "/auth/agreements"
-        case .postEmailCode:
-            return "/auth/verification/email"
         case .postUserLogin:
             return "/auth/sign-in"
+        case .postVerificaitonCode:
+            return "/auth/verification/email"
+        case .getCheckVerificationCode(let code):
+            return "/auth/verification?code=\(code)"
         }
     }
     
@@ -43,10 +48,12 @@ extension AuthTarget: TargetType {
         switch self {
         case .getAgreements:
             return nil
-        case .postEmailCode(let email):
-            return ["email": email]
         case .postUserLogin(email: let email, password: let password):
             return ["email": email, "password": password]
+        case .postVerificaitonCode(email: let email):
+            return ["email": email]
+        case .getCheckVerificationCode:
+            return nil
         }
     }
     
@@ -54,10 +61,12 @@ extension AuthTarget: TargetType {
         switch self {
         case .getAgreements:
             return nil
-        case .postEmailCode:
-            return ["Content-Type": "application/json"]
         case .postUserLogin:
             return ["Content-Type": "application/json"]
+        case .postVerificaitonCode:
+            return ["Content-Type": "application/json"]
+        case .getCheckVerificationCode:
+            return nil
         }
     }
 }

--- a/EveryTip/Targets/EveryTipData/Sources/Services/DTO/BaseResponseDTO.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/DTO/BaseResponseDTO.swift
@@ -9,12 +9,10 @@
 import Foundation
 
 public struct BaseResponseDTO: Decodable {
-    public let statusCode: Int
     public let code: String?
     public let message: String
     
-    public init(statusCode: Int ,code: String? = nil, message: String) {
-        self.statusCode = statusCode
+    public init(code: String? = nil, message: String) {
         self.code = code
         self.message = message
     }

--- a/EveryTip/Targets/EveryTipData/Sources/Services/DTO/BaseResponseDTO.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/DTO/BaseResponseDTO.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct BaseResponseDTO: Decodable {
+public struct BaseResponseDTO: Decodable, CodeCheckable {
     public let code: String?
     public let message: String
     

--- a/EveryTip/Targets/EveryTipData/Sources/Services/DTO/BaseResponseDTO.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/DTO/BaseResponseDTO.swift
@@ -1,0 +1,21 @@
+//
+//  BaseResponseDTO.swift
+//  EveryTipData
+//
+//  Created by 김경록 on 3/14/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import Foundation
+
+public struct BaseResponseDTO: Decodable {
+    public let statusCode: Int
+    public let code: String?
+    public let message: String
+    
+    public init(statusCode: Int ,code: String? = nil, message: String) {
+        self.statusCode = statusCode
+        self.code = code
+        self.message = message
+    }
+}

--- a/EveryTip/Targets/EveryTipData/Sources/Services/DTO/Protocol/CodeCheckable.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/DTO/Protocol/CodeCheckable.swift
@@ -1,0 +1,20 @@
+//
+//  CodeCheckable.swift
+//  EveryTipData
+//
+//  Created by 김경록 on 3/24/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import Foundation
+
+protocol CodeCheckable {
+    var code: String? { get }
+    func isSuccess() -> Bool
+}
+
+extension CodeCheckable {
+    func isSuccess() -> Bool {
+        return code == "SUCCESS"
+    }
+}

--- a/EveryTip/Targets/EveryTipData/Sources/Services/Network/MockURLProtocol.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/Network/MockURLProtocol.swift
@@ -1,0 +1,57 @@
+//
+//  MockURLProtocol.swift
+//  EveryTipData
+//
+//  Created by 김경록 on 3/14/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+final class MockURLProtocol: URLProtocol {
+    static var mockResponse: (data: Data?, response: HTTPURLResponse?, error: Error?)?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+    
+    override class func requestIsCacheEquivalent(_ a: URLRequest, to b: URLRequest) -> Bool {
+        return false
+    }
+
+    override func startLoading() {
+        if let response = MockURLProtocol.mockResponse?.response {
+            client?.urlProtocol(
+                self, didReceive: response,
+                cacheStoragePolicy: .notAllowed
+            )
+        }
+
+        if let data = MockURLProtocol.mockResponse?.data {
+            client?.urlProtocol(self, didLoad: data)
+        }
+
+        if let error = MockURLProtocol.mockResponse?.error {
+            client?.urlProtocol(self, didFailWithError: error)
+        } else {
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() { }
+}
+
+final class MockSession {
+    static func getMockSession() -> Session {
+        let configuration = URLSessionConfiguration.ephemeral
+        // MockURLProtocol을 사용하도록 설정
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return Session(configuration: configuration)
+    }
+}

--- a/EveryTip/Targets/EveryTipData/Sources/Services/Network/NetworkError.swift
+++ b/EveryTip/Targets/EveryTipData/Sources/Services/Network/NetworkError.swift
@@ -18,6 +18,7 @@ enum NetworkError: LocalizedError {
     case requestAdaptationError(Error)
     case requestRetryError(Error)
     case baseURLError
+    case invalidEmail
     
     var errorDescription: String? {
         switch self {
@@ -39,6 +40,8 @@ enum NetworkError: LocalizedError {
             return "요청 재시도 오류: \(error.localizedDescription)"
         case .baseURLError:
             return "plist에서 BaseURL을 가져오는데에 실패했어요"
+        case .invalidEmail:
+            return "사용 불가능한 이메일입니다."
         }
     }
 }

--- a/EveryTip/Targets/EveryTipData/Tests/AppIOSTestUITests.swift
+++ b/EveryTip/Targets/EveryTipData/Tests/AppIOSTestUITests.swift
@@ -1,8 +1,180 @@
-import Foundation
 import XCTest
+import Foundation
 
+import Alamofire
+import RxSwift
+
+@testable import EveryTipDomain
+@testable import EveryTipData
 final class AppIOSTestUITests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("AppIOSTestUI", "AppIOSTestUI")
+    var verfificationCodeRepository: DefaultVerificationCodeRepository!
+    var disposeBag: DisposeBag!
+    
+    override func setUp() {
+        super.setUp()
+        disposeBag = DisposeBag()
+        
+        // Given: Mock 세션을 사용하여 DefaultVerificationCodeRepository 초기화
+        verfificationCodeRepository = DefaultVerificationCodeRepository(session: MockSession.getMockSession())
+    }
+    
+    override func tearDown() {
+        verfificationCodeRepository = nil
+        disposeBag = nil
+        super.tearDown()
+    }
+
+    func test_requestCode_statusCode가_200일경우() {
+        // Given: 성공적인 응답을 모의 설정
+        let mockData = """
+            {
+                "statusCode": 200,
+                "code": "SUCCESS",
+                "message": "Verification code sent successfully"
+            }
+            """.data(using: .utf8)
+        
+        let mockResponse = HTTPURLResponse(
+            url: URL(string: "https://mockurl.com")!,
+            statusCode: 200,  // statusCode가 200
+            httpVersion: nil,
+            headerFields: nil
+        )
+        MockURLProtocol.mockResponse = (data: mockData, response: mockResponse, error: nil)
+        
+        // When: requestCode 메서드 호출
+        let expectation = self.expectation(description: "Request should succeed")
+        
+        verfificationCodeRepository.requestCode(with: "test@example.com")
+            .subscribe(
+                onCompleted: {
+                    // Then: 요청이 성공했을 때 expectation.fulfill()
+                    expectation.fulfill()
+                },
+                onError: { error in
+                    XCTFail("Request should not fail: \(error)")
+                }
+            ).disposed(by: disposeBag)
+        
+        // expectation이 fulfill 될 때까지 기다림
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    // Given-When-Then 패턴을 추가한 두 번째 테스트
+    func test_requestCode_statusCode가_400일경우() {
+        // Given: statusCode가 400인 응답을 모의 설정 (잘못된 요청)
+        let mockData = "{\"code\": \"FAIL\"}".data(using: .utf8)
+        let mockResponse = HTTPURLResponse(
+            url: URL(string: "https://mockurl.com")!,
+            statusCode: 400,  // statusCode가 400 (잘못된 요청)
+            httpVersion: nil,
+            headerFields: nil
+        )
+        MockURLProtocol.mockResponse = (data: mockData, response: mockResponse, error: nil)
+        
+        // When: requestCode 메서드 호출
+        let expectation = self.expectation(description: "Request should fail with invalid status code")
+        
+        verfificationCodeRepository.requestCode(with: "test@example.com")
+            .subscribe(
+                onCompleted: {
+                    // Then: 실패할 경우 expectation.fulfill()
+                    XCTFail("Request should fail due to invalid status code")
+                },
+                onError: { error in
+                    // Then: 오류가 발생할 경우 expectation.fulfill()
+                    expectation.fulfill()
+                    
+                    // 오류가 AFError 타입인지 확인하고, 상태 코드가 400인지 확인
+                    if let afError = error as? AFError {
+                        XCTAssertEqual(afError.responseCode, 400)
+                    } else {
+                        XCTFail("Unexpected error type")
+                    }
+                }
+            ).disposed(by: disposeBag)
+        
+        // expectation이 fulfill 될 때까지 기다림
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    func test_checkCode_statusCode가_200일경우() {
+        // Given: 성공적인 응답을 모의 설정
+        let mockData = """
+            {
+                "statusCode": 200,
+                "code": "SUCCESS",
+                "message": "Verification code is valid"
+            }
+            """.data(using: .utf8)
+        
+        let mockResponse = HTTPURLResponse(
+            url: URL(string: "https://mockurl.com")!,
+            statusCode: 200,  // statusCode가 200 (성공)
+            httpVersion: nil,
+            headerFields: nil
+        )
+        MockURLProtocol.mockResponse = (data: mockData, response: mockResponse, error: nil)
+        
+        // When: checkCode 메서드 호출
+        let expectation = self.expectation(description: "Request should succeed")
+        
+        verfificationCodeRepository.checkCode(with: "validCode123")
+            .subscribe(
+                onCompleted: {
+                    // Then: 요청이 성공했을 때 expectation.fulfill()
+                    expectation.fulfill()
+                },
+                onError: { error in
+                    XCTFail("Request should not fail: \(error)")
+                }
+            ).disposed(by: disposeBag)
+        
+        // expectation이 fulfill 될 때까지 기다림
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+    
+    func test_checkCode_statusCode가_400일경우() {
+        // Given: statusCode가 400인 응답을 모의 설정 (잘못된 요청)
+        let mockData = """
+            {
+                "statusCode": "400",
+                "code": "FAIL",
+                "message": "Invalid verification code"
+            }
+            """.data(using: .utf8)
+        
+        let mockResponse = HTTPURLResponse(
+            url: URL(string: "https://mockurl.com")!,
+            statusCode: 400,  // statusCode가 400 (잘못된 요청)
+            httpVersion: nil,
+            headerFields: nil
+        )
+        MockURLProtocol.mockResponse = (data: mockData, response: mockResponse, error: nil)
+        
+        // When: checkCode 메서드 호출
+        let expectation = self.expectation(description: "Request should fail with invalid status code")
+        
+        verfificationCodeRepository.checkCode(with: "invalidCode123")
+            .subscribe(
+                onCompleted: {
+                    // Then: 요청이 실패했을 때 expectation.fulfill()
+                    XCTFail("Request should fail due to invalid status code")
+                },
+                onError: { error in
+                    // Then: 실패 시 expectation.fulfill()
+                    expectation.fulfill()
+                    
+                    // 오류가 AFError 타입인지 확인하고, 상태 코드가 400인지 확인
+                    if let afError = error as? AFError {
+                        XCTAssertEqual(afError.responseCode, 400)
+                    } else {
+                        XCTFail("Unexpected error type")
+                    }
+                }
+            ).disposed(by: disposeBag)
+        
+        // expectation이 fulfill 될 때까지 기다림
+        waitForExpectations(timeout: 5, handler: nil)
     }
 }


### PR DESCRIPTION
## 이슈 번호: #67 

## PR 타입

- [x] 기능 구현
- [ ] 오류 수정
- [ ] 리팩토링

<br>

### 작업 내용

> 구현 및 작업 내용을 작성합니다.

- URLProtocol을 서브클래싱하여 Alamofire 에서의 테스트 환경을 구성했습니다.
모든 요청이 동일한 모의 응답을 사용할 수 있길 기대하고 mockResponse를 static으로 선언하였습니다.
- VerificaitonCode 레포지토리의 구현체를 정의했습니다.
request의 경우 테스트 해 본 결과 없는 이메일, 빈번한 요청 등에 의해 FAIL을 반환하여 따로 처리해준 부분이 있습니다

- 이전 PR에 있던 DTO를 정의했습니다.
현재 API 응답이 statusCode, status로 혼용되고 있는 부분을 백엔드에게 수정 요청한 상태고 우선은 statusCode로 명명해두었습니다 추후 변경될 수 있습니다.
Data가 있는 버전은 DataResponseDTO로 네이밍 예정중입니다.

<br>

### PR 체크리스트

- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항

> PR 리뷰 시 주의 깊게 보거나 유의해야 할 점들과 기타 사항을 작성합니다.

- 유의 사항 1
- 기타 사항 1

<br>
