### PR TITLE
Feat/#62/회원가입 뷰

### DIFF
--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/AuthenticationCoordinator.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/AuthenticationCoordinator.swift
@@ -34,7 +34,8 @@ extension AuthenticationCoordinator {
     
     func pushToLoginView() {
         let loginCoordinator: LoginCoordinator = DefaultLoginCoordinator(navigationController: navigationController)
-        
+        loginCoordinator.parentCoordinator = self
+        self.childCoordinators.append(loginCoordinator)
         loginCoordinator.start()
     }
     

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/EveryTipTextFieldView.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/EveryTipTextFieldView.swift
@@ -101,12 +101,13 @@ final class EveryTipTextFieldView: UIView {
         hasSecureTextButton: Bool = false,
         textFieldRightInset: CGFloat = 16
     ) {
-        textField.clearButtonMode = hasClearButton ? .always : .never
+        textField.clearButtonMode = hasClearButton ? .whileEditing : .never
         textField.isSecureTextEntry = hasSecureTextButton
         self.textFieldRightInset = textFieldRightInset
         super.init(frame: .zero)
         setupLayout()
         setupConstraints()
+        setupGuideMessagePriority()
         bind()
     }
     
@@ -116,6 +117,11 @@ final class EveryTipTextFieldView: UIView {
     }
     
     // MARK: -
+    
+    private func setupGuideMessagePriority() {
+        guideMessageLabel.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        guideMessageLabel.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+    }
     
     private func setupLayout() {
         addSubview(containerStackView)
@@ -177,24 +183,35 @@ final class EveryTipTextFieldView: UIView {
         let statusBinder: Binder<EveryTipTextFieldStatus> = Binder(self) { view, status in
             switch status {
             case .normal:
+                view.textField.isEnabled = true
+                view.borderView.backgroundColor = .white
                 view.borderView.layer.borderColor = view.borderColorWhenNormal.cgColor
                 view.setGuideMessageViewIsHiddenWithAnimate(isHidden: true)
                 
             case .editing:
+                view.textField.isEnabled = true
+                view.borderView.backgroundColor = .white
                 view.borderView.layer.borderColor = view.borderColorWhenEditing.cgColor
                 
             case .success:
+                view.textField.isEnabled = true
+                view.borderView.backgroundColor = .white
                 view.borderView.layer.borderColor = view.borderColorWhenSuccess.cgColor
                 view.guideMessageLabel.textColor = view.borderColorWhenSuccess
                 let isHidden = view.guideMessageLabel.text == nil
                 view.setGuideMessageViewIsHiddenWithAnimate(isHidden: isHidden)
                 
             case .error:
+                view.textField.isEnabled = true
+                view.borderView.backgroundColor = .white
                 view.borderView.layer.borderColor = view.borderColorWhenError.cgColor
                 view.guideMessageLabel.textColor = view.borderColorWhenError
                 view.setGuideMessageViewIsHiddenWithAnimate(isHidden: false)
                 
             case .notEnabled:
+                view.textField.resignFirstResponder()
+                view.textField.isEnabled = false
+                view.borderView.backgroundColor = UIColor.et_lineGray20
                 view.borderView.layer.borderColor = view.borderColorWhenNotEnabled.cgColor
                 view.setGuideMessageViewIsHiddenWithAnimate(isHidden: true)
             }

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/TitleDescriptionView.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/TitleDescriptionView.swift
@@ -31,6 +31,7 @@ final class TitleDescriptionView: UIView {
             size: 16
         )
         label.textColor = UIColor(hex: "#777777")
+        label.numberOfLines = 0
         
         return label
     }()

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/TitleDescriptionView.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/TitleDescriptionView.swift
@@ -1,0 +1,77 @@
+//
+//  TitleDescriptionView.swift
+//  EveryTipPresentation
+//
+//  Created by 김경록 on 4/7/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import UIKit
+
+import EveryTipDesignSystem
+
+import SnapKit
+
+final class TitleDescriptionView: UIView {
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .et_pretendard(
+            style: .bold,
+            size: 24
+        )
+        label.textColor = .black
+        
+        return label
+    }()
+    
+    private let subTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .et_pretendard(
+            style: .regular,
+            size: 16
+        )
+        label.textColor = UIColor(hex: "#777777")
+        
+        return label
+    }()
+
+    init(title: String, subTitle: String) {
+        super.init(frame: .zero)
+        setupLayout()
+        setupConstraints()
+        configure(title: title, subTitle: subTitle)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayout() {
+        self.addSubViews(
+            titleLabel,
+            subTitleLabel
+        )
+    }
+    
+    private func setupConstraints() {
+        
+        self.snp.makeConstraints {
+            $0.height.equalTo(56)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(self.snp.top)
+            $0.leading.equalTo(self.snp.leading)
+        }
+        
+        subTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+            $0.leading.equalTo(self.snp.leading)
+        }
+    }
+    
+    private func configure(title: String, subTitle: String) {
+        titleLabel.text = title
+        subTitleLabel.text = subTitle
+    }
+}

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Login/LoginCoordinator.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Login/LoginCoordinator.swift
@@ -13,6 +13,7 @@ import Swinject
 
 protocol LoginCoordinator: Coordinator {
     func startAndReturnViewController() -> UIViewController
+    func pushToSignupView()
 }
 
 final class DefaultLoginCoordinator: LoginCoordinator {
@@ -51,6 +52,13 @@ final class DefaultLoginCoordinator: LoginCoordinator {
         loginViewController.coordinator = self
         return loginViewController
     }
+    
+    func pushToSignupView() {
+           let signUpCoordinator = DefaultSignupCoordinator(navigationController: navigationController)
+           signUpCoordinator.parentCoordinator = self
+           self.append(child: signUpCoordinator)
+           signUpCoordinator.start()
+       }
     
     func didFinish() {
         parentCoordinator?.remove(child: self)

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Login/LoginViewController.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Login/LoginViewController.swift
@@ -92,6 +92,7 @@ final class LoginViewController: BaseViewController {
         super.viewDidLoad()
         setupLayout()
         setupConstraints()
+        signupButton.addTarget(self, action: #selector(pushToSignUpView), for: .touchUpInside)
     }
     
     init(reactor: LoginReactor) {
@@ -165,6 +166,11 @@ final class LoginViewController: BaseViewController {
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
             $0.height.equalTo(56)
         }
+    }
+    
+    @objc
+    private func pushToSignUpView() {
+        coordinator?.pushToSignupView()
     }
 }
 

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Login/LoginViewController.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Login/LoginViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
- 
+
 import SnapKit
 import ReactorKit
 import RxSwift
@@ -69,7 +69,7 @@ final class LoginViewController: BaseViewController {
         return label
     }()
     
-    private let registerButton: UIButton = {
+    private let signupButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("회원가입", for: .normal)
         button.titleLabel?.font = UIFont.et_pretendard(style: .medium, size: 14)
@@ -117,7 +117,7 @@ final class LoginViewController: BaseViewController {
             loginButton,
             searchPasswordButton,
             separator,
-            registerButton
+            signupButton
         )
     }
     
@@ -143,7 +143,7 @@ final class LoginViewController: BaseViewController {
             $0.top.equalTo(emailTextFieldView.snp.bottom).offset(10)
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
-  
+        
         searchPasswordButton.snp.makeConstraints {
             $0.top.equalTo(passwordTextFieldView.snp.bottom).offset(8)
             $0.trailing.equalTo(separator.snp.leading).offset(-20)
@@ -154,7 +154,7 @@ final class LoginViewController: BaseViewController {
             $0.centerX.equalTo(view.center.x)
         }
         
-        registerButton.snp.makeConstraints {
+        signupButton.snp.makeConstraints {
             $0.top.equalTo(passwordTextFieldView.snp.bottom).offset(8)
             
             $0.leading.equalTo(separator.snp.trailing).offset(20)

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupCoordinator.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupCoordinator.swift
@@ -1,0 +1,47 @@
+//
+//  SignupCoordinator.swift
+//  EveryTipPresentation
+//
+//  Created by 김경록 on 4/7/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import UIKit
+
+import EveryTipDomain
+
+import Swinject
+
+protocol SignupCoordinator: Coordinator { }
+
+final class DefaultSignupCoordinator: SignupCoordinator {
+    var parentCoordinator: (any Coordinator)?
+    
+    var childCoordinators: [any Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func start() {
+        guard let authUseCase = Container.shared.resolve(AuthUseCase.self) else {
+            fatalError("의존성 주입이 올바르지않습니다")
+        }
+        
+        let reactor = SignUpReactor(authUseCase: authUseCase)
+        
+        let signUpViewController = SignUpViewController(reactor: reactor)
+        
+        signUpViewController.coordinator = self
+        navigationController.pushViewController(
+            signUpViewController,
+            animated: true
+        )
+    }
+    
+    func didFinish() {
+        parentCoordinator?.remove(child: self)
+    }
+}

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupReactor.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupReactor.swift
@@ -13,6 +13,8 @@ import EveryTipDomain
 import ReactorKit
 import RxSwift
 
+// TODO: MVVM 관점에서의 관심사 분리 고려 필요
+
 final class SignUpReactor: Reactor {
     private let timerSubject = BehaviorSubject<Observable<Mutation>>(value: Observable.empty())
     private var timerStream: Observable<Mutation> {

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupReactor.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupReactor.swift
@@ -24,6 +24,7 @@ final class SignUpReactor: Reactor {
         .take(while: { $0 >= 0 })
         .map { Mutation.updateTimerState(isHidden: false, remainTime: $0) }
         .do(onDispose: { print("타이머 해제") })
+        .share(replay: 1, scope: .whileConnected)
     
     enum VerificationButtonState {
         case beforeSending

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupReactor.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupReactor.swift
@@ -39,7 +39,6 @@ final class SignUpReactor: Reactor {
     }
     
     enum Action {
-        case viewDidLoad
         case verifyButtonTapped(email: String)
         case textFieldAction(type: TextFieldType, action: EveryTipTextFieldAction)
         case submitButtonTapped
@@ -84,8 +83,6 @@ final class SignUpReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
-            return Observable.empty()
         case .verifyButtonTapped(let email):
             return handleVerifyButton(email: email)
         case .textFieldAction(let type, let action):

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupReactor.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupReactor.swift
@@ -1,0 +1,278 @@
+//
+//  SignupReactor.swift
+//  EveryTipPresentation
+//
+//  Created by 김경록 on 4/7/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import UIKit
+
+import EveryTipDomain
+
+import ReactorKit
+import RxSwift
+
+final class SignUpReactor: Reactor {
+    private let timerSubject = BehaviorSubject<Observable<Mutation>>(value: Observable.empty())
+    private var timerStream: Observable<Mutation> {
+        return timerSubject.switchLatest()
+    }
+    private let timer = Observable<Int>
+        .interval(.seconds(1), scheduler: MainScheduler.asyncInstance)
+        .map { 300 - $0 }
+        .take(while: { $0 >= 0 })
+        .map { Mutation.updateTimerState(isHidden: false, remainTime: $0) }
+        .do(onDispose: { print("타이머 해제") })
+    
+    enum VerificationButtonState {
+        case beforeSending
+        case afterSent
+        case afterVerified
+    }
+    
+    enum TextFieldType {
+        case email
+        case verificationCode
+        case password
+        case confirmPassword
+    }
+    
+    enum Action {
+        case viewDidLoad
+        case verifyButtonTapped(email: String)
+        case textFieldAction(type: TextFieldType, action: EveryTipTextFieldAction)
+        case submitButtonTapped
+    }
+    
+    enum Mutation {
+        case updateVerifiedLabelVisibility(Bool)
+        case updateCheckEmailButtonState(VerificationButtonState)
+        case updateTimerState(isHidden: Bool, remainTime: Int)
+        case updateTextField(
+            type: TextFieldType,
+            text: String?,
+            status: EveryTipTextFieldStatus,
+            errorMessage: String? = nil
+        )
+        case updateSubmitButtonEnabledState(Bool)
+    }
+    
+    struct State {
+        var isVerificationCompletedLabelHidden = true
+        var checkEmailButtonState: VerificationButtonState = .beforeSending
+        var isSubmitButtonEnabled = false
+        var remainingTime = 0
+        var isTimerHidden = true
+        var textFieldText: [TextFieldType: String] = [:]
+        var textFieldStatus: [TextFieldType: (status: EveryTipTextFieldStatus, errorMessage: String?)] = [:]
+    }
+    
+    var initialState: State
+    private let authUseCase: AuthUseCase?
+    
+    init(authUseCase: AuthUseCase) {
+        self.initialState = State(
+            textFieldStatus: [
+                .verificationCode: (.notEnabled, nil),
+                .password: (.notEnabled, nil),
+                .confirmPassword: (.notEnabled, nil)
+            ]
+        )
+        self.authUseCase = authUseCase
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .viewDidLoad:
+            return Observable.empty()
+        case .verifyButtonTapped(let email):
+            return handleVerifyButton(email: email)
+        case .textFieldAction(let type, let action):
+            return handleTextFieldAction(type: type, action: action)
+        case .submitButtonTapped:
+            return handleSubmit()
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .updateVerifiedLabelVisibility(let hidden):
+            newState.isVerificationCompletedLabelHidden = hidden
+        case .updateCheckEmailButtonState(let buttonState):
+            newState.checkEmailButtonState = buttonState
+        case .updateTimerState(let hidden, let time):
+            newState.isTimerHidden = hidden
+            newState.remainingTime = time
+        case .updateTextField(let type, let text, let status, let errorMessage):
+            if let textValue = text {
+                newState.textFieldText[type] = textValue
+            }
+            newState.textFieldStatus[type] = (status, errorMessage)
+        case .updateSubmitButtonEnabledState(let isEnabled):
+            newState.isSubmitButtonEnabled = isEnabled
+        }
+        return newState
+    }
+    
+    // MARK: - Handlers
+    
+    private func handleVerifyButton(email: String) -> Observable<Mutation> {
+        guard let authUseCase = authUseCase else { return Observable.empty() }
+        guard checkRegex(textType: .email, text: email) else {
+            return Observable.just(
+                .updateTextField(
+                    type: .email,
+                    text: nil,
+                    status: .error,
+                    errorMessage: "이메일 형식으로 입력해주세요"
+                )
+            )
+        }
+        timerSubject.onNext(timer)
+        return authUseCase.requestEmailCode(email: email)
+            .andThen(
+                Observable.concat([
+                    .just(.updateTextField(type: .verificationCode, text: nil, status: .normal)),
+                    .just(.updateVerifiedLabelVisibility(true)),
+                    .just(.updateCheckEmailButtonState(.afterSent)),
+                    timerStream
+                ])
+            )
+            .catch { _ in
+                Observable.just(
+                    .updateTextField(
+                        type: .email,
+                        text: nil,
+                        status: .error,
+                        errorMessage: "이메일을 다시 확인해주세요."
+                    )
+                )
+            }
+    }
+    
+    private func handleTextFieldAction(type: TextFieldType, action: EveryTipTextFieldAction) -> Observable<Mutation> {
+        switch action {
+        case .textChanged(let text):
+            return handleTextChanged(type: type, text: text)
+        case .editingDidBegin:
+            return Observable.just(.updateTextField(type: type, text: nil, status: .editing))
+        case .editingDidEnd:
+            if type == .verificationCode {
+                return Observable.empty()
+            }
+            return Observable.just(.updateTextField(type: type, text: nil, status: .normal))
+        case .editingDidEndOnExit:
+            return Observable.just(.updateTextField(type: type, text: nil, status: .normal))
+        }
+    }
+    
+    private func handleTextChanged(type: TextFieldType, text: String) -> Observable<Mutation> {
+        switch type {
+        case .email:
+            return Observable.just(.updateTextField(type: .email, text: text, status: .editing))
+        case .verificationCode:
+            return handleVerificationCode(text)
+        case .password:
+            let isValidPassword = checkRegex(textType: .password, text: text)
+            return Observable.just(
+                .updateTextField(
+                    type: .password,
+                    text: text,
+                    status: isValidPassword ? .editing : .error,
+                    errorMessage: isValidPassword ? nil : "영문 + 숫자 조합 8자리 이상 입력해 주세요."
+                )
+            )
+        case .confirmPassword:
+            return handleConfirmPassword(text)
+        }
+    }
+    
+    private func handleVerificationCode(_ text: String) -> Observable<Mutation> {
+        guard let authUseCase = authUseCase else { return Observable.empty() }
+        guard checkRegex(textType: .verifyCode, text: text) else {
+            return Observable.just(
+                .updateTextField(
+                    type: .verificationCode,
+                    text: text,
+                    status: .error,
+                    errorMessage: "숫자 4자리만 입력해주세요"
+                )
+            )
+        }
+        if text.count == 4 && currentState.remainingTime > 0 {
+            return authUseCase.checkEmailCode(code: text)
+                .observe(on: MainScheduler.asyncInstance)
+                .andThen(
+                    Observable.concat([
+                        .just(.updateTimerState(isHidden: true, remainTime: 0)),
+                        .just(.updateCheckEmailButtonState(.afterVerified)),
+                        .just(.updateTextField(type: .email, text: nil, status: .notEnabled)),
+                        .just(.updateTextField(type: .verificationCode, text: nil, status: .notEnabled)),
+                        .just(.updateTextField(type: .password, text: nil, status: .normal)),
+                        .just(.updateTextField(type: .confirmPassword, text: nil, status: .normal)),
+                        .just(.updateVerifiedLabelVisibility(false))
+                    ])
+                )
+                .catch { _ in
+                    Observable.just(
+                        .updateTextField(
+                            type: .verificationCode,
+                            text: text,
+                            status: .error,
+                            errorMessage: "인증번호를 다시 확인해주세요"
+                        )
+                    )
+                }
+        }
+        return Observable.just(.updateTextField(type: .verificationCode, text: text, status: .editing))
+    }
+    
+    private func handleConfirmPassword(_ text: String) -> Observable<Mutation> {
+        let passwordText = currentState.textFieldText[.password] ?? ""
+        let isMatching = passwordText == text && checkRegex(textType: .password, text: text)
+        let status: EveryTipTextFieldStatus = isMatching ? .editing : .error
+        let errorMessage = status == .error ? "비밀번호가 일치하지 않습니다." : nil
+        let enableSubmit = Observable.just(Mutation.updateSubmitButtonEnabledState(isMatching))
+        return Observable.concat([
+            .just(
+                .updateTextField(
+                    type: .confirmPassword,
+                    text: text,
+                    status: status,
+                    errorMessage: errorMessage
+                )
+            ),
+            enableSubmit
+        ])
+    }
+    
+    private func handleSubmit() -> Observable<Mutation> {
+        // TODO: 이메일 및 비밀번호 데이터 저장 및 다음 화면 넘어가기
+        return Observable.empty()
+    }
+}
+
+// MARK: - Regex Helper
+private enum TextType {
+    case email
+    case password
+    case verifyCode
+}
+
+private func checkRegex(textType: TextType, text: String?) -> Bool {
+    guard let text = text else {
+        return false
+    }
+    switch textType {
+    case .email:
+        let pattern = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+        return text.range(of: pattern, options: .regularExpression) != nil
+    case .password:
+        let pattern = "(?=.*[A-Za-z])(?=.*\\d).{8,}"
+        return text.range(of: pattern, options: .regularExpression) != nil
+    case .verifyCode:
+        return Int(text) != nil
+    }
+}

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupViewController.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupViewController.swift
@@ -1,0 +1,431 @@
+//
+//  SignupViewController.swift
+//  EveryTipPresentation
+//
+//  Created by 김경록 on 4/7/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import UIKit
+
+import EveryTipDesignSystem
+import EveryTipDomain
+
+import SnapKit
+import RxSwift
+import ReactorKit
+
+final class SignUpViewController: BaseViewController {
+    
+    weak var coordinator: SignupCoordinator?
+    
+    var disposeBag = DisposeBag()
+
+    private let titleView: TitleDescriptionView = {
+        let view = TitleDescriptionView(
+            title: "회원가입",
+            subTitle: "회원 여부 확인 및 가입을 진행합니다"
+        )
+                
+        return view
+    }()
+    
+    private let emailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "아이디(이메일)"
+        label.font = .et_pretendard(style: .medium, size: 16)
+        
+        return label
+    }()
+    
+    private let emailTextFieldView: EveryTipTextFieldView = {
+        let etView = EveryTipTextFieldView(
+            hasClearButton: true,
+            textFieldRightInset: 90
+        )
+        
+        etView.textField.placeholder = "예) everytip@everytip.com"
+        etView.textField.keyboardType = .emailAddress
+        etView.textField.autocapitalizationType = .none
+        
+        return etView
+    }()
+    
+    private let verifyButton: UIButton = {
+        let button = UIButton(type: .system)
+        
+        button.titleLabel?.font = .et_pretendard(
+            style: .bold,
+            size: 14
+        )
+        button.tintColor = .et_brandColor2
+        button.backgroundColor = .et_brandColor2.withAlphaComponent(0.15)
+        button.layer.cornerRadius = 6
+        button.setTitle("인증하기", for: .normal)
+        
+        return button
+    }()
+    
+    private let verificationCodeTextFieldView: EveryTipTextFieldView = {
+        let etView = EveryTipTextFieldView(
+            hasClearButton: false,
+            textFieldRightInset: 90
+        )
+        etView.textField.keyboardType = .numberPad
+        etView.textField.placeholder = "인증번호 4자리 입력"
+        etView.textField.autocapitalizationType = .none
+        
+        return etView
+    }()
+    
+    private let timerLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .et_brandColor2
+        label.isHidden = true
+        
+        return label
+    }()
+    
+    private let verificationCompletedLabel: UILabel = {
+        let label = UILabel()
+        label.backgroundColor = .et_textColor5
+        label.textColor = .et_lineGray20
+        label.text = "✓ 인증완료"
+        label.font = .et_pretendard(
+            style: .bold,
+            size: 14
+        )
+        label.textAlignment = .center
+        label.layer.cornerRadius = 6
+        label.layer.masksToBounds = true
+        
+        return label
+    }()
+    
+    private let separator: StraightLineView = {
+        let line = StraightLineView(color: .et_lineGray20)
+        
+        return line
+    }()
+    
+    private let passwordLabel: UILabel = {
+        let label = UILabel()
+        label.text = "비밀번호"
+        return label
+    }()
+    
+    private let passwordTextFieldView: EveryTipTextFieldView = {
+        let etView = EveryTipTextFieldView(
+            hasClearButton: true,
+            hasSecureTextButton: true,
+            textFieldRightInset: 16
+        )
+        
+        etView.textField.placeholder = "비밀번호 입력 (영문+숫자 조합 8자리 이상)"
+        etView.textField.keyboardType = .asciiCapable
+        etView.textField.autocapitalizationType = .none
+        return etView
+    }()
+    
+    private let confirmPasswordTextFieldView: EveryTipTextFieldView = {
+        let etView = EveryTipTextFieldView(
+            hasClearButton: true,
+            hasSecureTextButton: true,
+            textFieldRightInset: 16
+        )
+        etView.textField.placeholder = "비밀번호 확인 입력"
+        etView.textField.keyboardType = .asciiCapable
+        etView.textField.autocapitalizationType = .none
+        
+        return etView
+    }()
+    
+    private let submitButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("다음", for: .normal)
+        button.isEnabled = false
+        button.backgroundColor = .et_textColor5
+        button.tintColor = .white
+        button.titleLabel?.font = .et_pretendard(style: .bold, size: 18)
+        button.layer.cornerRadius = 10
+        button.layer.masksToBounds = true
+        
+        return button
+    }()
+    
+    init(reactor: SignUpReactor) {
+        super.init(nibName: nil, bundle: nil)
+        self.reactor = reactor
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupLayout()
+        setupConstraints()
+        
+        // TODO: 커스텀 네비게이션으로 대체
+        self.navigationController?.navigationBar.tintColor = .black
+    }
+    
+    private func setupLayout() {
+        view.addSubViews(
+            titleView,
+            emailLabel,
+            emailTextFieldView,
+            verificationCodeTextFieldView,
+            timerLabel,
+            separator,
+            passwordLabel,
+            passwordTextFieldView,
+            confirmPasswordTextFieldView,
+            submitButton,
+            verificationCompletedLabel
+        )
+        view.addSubview(verifyButton)
+    }
+    
+    private func setupConstraints() {
+        titleView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(32)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(20)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        emailLabel.snp.makeConstraints {
+            $0.top.equalTo(titleView.snp.bottom).offset(40)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(20)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        emailTextFieldView.snp.makeConstraints {
+            $0.top.equalTo(emailLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.greaterThanOrEqualTo(52)
+        }
+        
+        verifyButton.snp.makeConstraints {
+            $0.width.equalTo(74)
+            $0.height.equalTo(36)
+            $0.centerY.equalTo(emailTextFieldView.textField.snp.centerY)
+            $0.trailing.equalTo(emailTextFieldView.snp.trailing).offset(-8)
+        }
+        
+        verificationCodeTextFieldView.snp.makeConstraints {
+            $0.top.equalTo(emailTextFieldView.snp.bottom).offset(10)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.greaterThanOrEqualTo(52)
+        }
+        
+        verificationCompletedLabel.snp.makeConstraints {
+            $0.width.equalTo(verificationCodeTextFieldView.textField.snp.width).multipliedBy(0.36)
+            $0.height.equalTo(verificationCodeTextFieldView.textField.snp.height).multipliedBy(0.69)
+            $0.centerY.equalTo(verificationCodeTextFieldView.textField.snp.centerY)
+            $0.trailing.equalTo(verificationCodeTextFieldView.snp.trailing).offset(-9)
+        }
+        
+        timerLabel.snp.makeConstraints {
+            $0.centerY.equalTo(verificationCodeTextFieldView.textField.snp.centerY)
+            $0.trailing.equalTo(verificationCodeTextFieldView.snp.trailing).offset(-26)
+        }
+        
+        separator.snp.makeConstraints {
+            $0.top.equalTo(verificationCodeTextFieldView.snp.bottom).offset(32)
+            $0.leading.trailing.equalTo(view)
+            $0.height.equalTo(8)
+        }
+        
+        passwordLabel.snp.makeConstraints {
+            $0.top.equalTo(separator.snp.bottom).offset(32)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(20)
+        }
+        
+        passwordTextFieldView.snp.makeConstraints {
+            $0.top.equalTo(passwordLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.greaterThanOrEqualTo(52)
+        }
+        
+        confirmPasswordTextFieldView.snp.makeConstraints {
+            $0.top.greaterThanOrEqualTo(passwordTextFieldView.snp.bottom).offset(10)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.height.greaterThanOrEqualTo(52)
+        }
+        
+        submitButton.snp.makeConstraints {
+            $0.height.equalTo(56)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-20)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+    }
+}
+
+extension SignUpViewController: View {
+    func bind(reactor: SignUpReactor) {
+        bindInput(to: reactor)
+        bindOutput(to: reactor)
+    }
+    
+    func bindInput(to reactor: SignUpReactor) {
+        rx.viewDidLoad
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        verifyButton.rx.tap
+            .map { [weak self] in
+                let emailInput = self?.emailTextFieldView.textField.text ?? ""
+                return Reactor.Action.verifyButtonTapped(email: emailInput)
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        emailTextFieldView.action
+            .map { Reactor.Action.textFieldAction(type: .email, action: $0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        verificationCodeTextFieldView.action
+            .map { Reactor.Action.textFieldAction(type: .verificationCode, action: $0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // 최대 4글자로 제한
+        verificationCodeTextFieldView.textField.rx.text
+            .orEmpty
+            .map { String($0.prefix(4)) }
+            .bind(to: verificationCodeTextFieldView.textField.rx.text)
+            .disposed(by: disposeBag)
+        
+        passwordTextFieldView.action
+            .map { Reactor.Action.textFieldAction(
+                type: .password,
+                action: $0)
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        confirmPasswordTextFieldView.action
+            .map { Reactor.Action.textFieldAction(
+                type: .confirmPassword,
+                action: $0)
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        submitButton.rx.tap
+            .map { Reactor.Action.submitButtonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+    }
+    
+    func bindOutput(to reactor: SignUpReactor) {
+        reactor.state.map { $0.remainingTime }
+            .bind { [weak self] timerText in
+                
+                let minutes = timerText / 60
+                let seconds = timerText % 60
+                let timerString = String(format: "%d:%02d", minutes, seconds)
+                
+                self?.timerLabel.text = timerString
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.isTimerHidden }
+            .bind { [weak self] bool in
+                self?.timerLabel.isHidden = bool
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.textFieldStatus[.email]?.status }
+            .distinctUntilChanged()
+            .bind { [weak self] status in
+                self?.emailTextFieldView.status.onNext(status)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.textFieldStatus[.email]?.errorMessage }
+            .distinctUntilChanged()
+            .bind(to: self.emailTextFieldView.guideMessageLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.textFieldStatus[.verificationCode]?.status }
+            .distinctUntilChanged()
+            .bind { [weak self] status in
+                self?.verificationCodeTextFieldView.status.onNext(status)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.textFieldStatus[.verificationCode]?.errorMessage }
+            .distinctUntilChanged()
+            .bind(to: self.verificationCodeTextFieldView.guideMessageLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.textFieldStatus[.password]?.status }
+            .distinctUntilChanged()
+            .bind { [weak self] status in
+                self?.passwordTextFieldView.status.onNext(status)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.textFieldStatus[.password]?.errorMessage }
+            .distinctUntilChanged()
+            .bind(to: self.passwordTextFieldView.guideMessageLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.textFieldStatus[.confirmPassword]?.status }
+            .distinctUntilChanged()
+            .bind { [weak self] status in
+                self?.confirmPasswordTextFieldView.status.onNext(status)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.textFieldStatus[.confirmPassword]?.errorMessage }
+            .distinctUntilChanged()
+            .bind(to: self.confirmPasswordTextFieldView.guideMessageLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isVerificationCompletedLabelHidden }
+            .bind(to: verificationCompletedLabel.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.isSubmitButtonEnabled }
+            .distinctUntilChanged()
+            .bind(to: submitButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map {
+            $0.isSubmitButtonEnabled ? .et_brandColor2 : .et_textColor5
+        }
+        .bind(to: submitButton.rx.backgroundColor )
+        .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.checkEmailButtonState }
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] in
+                switch $0 {
+                case .beforeSending:
+                    self?.verifyButton.setTitle("인증하기", for: .normal)
+                case .afterSent:
+                    self?.verifyButton.setTitle("재전송", for: .normal)
+                case .afterVerified:
+                    self?.verifyButton.isHidden = true
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupViewController.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupViewController.swift
@@ -271,6 +271,11 @@ extension SignUpViewController: View {
     
     func bindInput(to reactor: SignUpReactor) {
         verifyButton.rx.tap
+            .throttle(
+                .seconds(5),
+                latest: false,
+                scheduler: MainScheduler.instance
+            )
             .map { [weak self] in
                 let emailInput = self?.emailTextFieldView.textField.text ?? ""
                 return Reactor.Action.verifyButtonTapped(email: emailInput)

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupViewController.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupViewController.swift
@@ -166,9 +166,6 @@ final class SignUpViewController: BaseViewController {
         super.viewDidLoad()
         setupLayout()
         setupConstraints()
-        
-        // TODO: 커스텀 네비게이션으로 대체
-        self.navigationController?.navigationBar.tintColor = .black
     }
     
     private func setupLayout() {

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupViewController.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Signup/SignupViewController.swift
@@ -270,11 +270,6 @@ extension SignUpViewController: View {
     }
     
     func bindInput(to reactor: SignUpReactor) {
-        rx.viewDidLoad
-            .map { Reactor.Action.viewDidLoad }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
         verifyButton.rx.tap
             .map { [weak self] in
                 let emailInput = self?.emailTextFieldView.textField.text ?? ""


### PR DESCRIPTION
## 이슈 번호: #62 

## PR 타입

- [x] 기능 구현
- [ ] 오류 수정
- [x] 리팩토링

<br>

### 작업 내용

> 구현 및 작업 내용을 작성합니다.
![image](https://github.com/user-attachments/assets/5169e348-e8c8-4398-beb8-196561222b56)

- 회원가입 뷰(이메일 비밀번호 입력부분)의 구현을 진행했습니다.
- etTextField를 활용하여 사용자 인터렉션에 대한 피드백을 제공하도록 했습니다.
- 해당 화면의 전반적인 화면의 플로우는 다음과 같습니다.
1. 화면 진입(이메일 필드 외엔 잠금)
2. 이메일 입력 후 인증번호 발급.
 과정에서 이메일 형태가 아닌 경우와 잘못된 이메일인 경우를 가이드 메세지를 통해 안내
3. 이메일의 검증 완료 후 메일 발송, **인증하기** 버튼은 **재전송** 버튼으로 변경
4. 5분의 타이머 시작 및 인증코드 필드의 오픈
5. 인증번호 입력
과정에서 숫자가 아니거나 틀렸을 경우를 가이드 메세지를 통해 안내
6. 인증번호의 검증 완료 후 비밀번호 필드를 오픈, 재전송 버튼과 타이머의 isHidden 처리 및 **인증완료** 레이블의 표시
7. 비밀번호의 입력
과정에서 입력시마다 영문+숫자 조합 8자리인지를 확인
8. 비밀번호 확인의 입력
이전 비밀번호와 동일하면 **다음** 버튼의 활성화
<br>

### PR 체크리스트

- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항

> PR 리뷰 시 주의 깊게 보거나 유의해야 할 점들과 기타 사항을 작성합니다.

- reactor 내부에서 switch문을 두번 돌게되는게 너무 가독성이 떨어져서 함수로 분리했습니다.
- 
![image](https://github.com/user-attachments/assets/185f4f13-4612-4591-9736-6fa9a237af21)
이번 PR에서는,
4자리 인증코드 입력 시 버튼 없이 자동으로 유효성 검증이 수행되도록 하는 동작에서 발생한 문제를 해결하기 위한 변경사항을 포함합니다.

⚠️ 발생한 문제
인증 코드 필드에 대해 다음과 같은 요구사항을 반영하려는 도중 문제가 발생했습니다:

사용자가 4자리를 모두 입력하면 즉시 인증 요청을 보내고,

이후 상태를 .notEnabled로 바꾸며 다음 입력 단계로 넘어감.

하지만 이 과정에서 다음과 같은 문제가 있었습니다:

textChanged, editingDidEnd 등 다양한 이벤트 스트림이 동시에 발생하는 상황에서,
인증 성공 후 .notEnabled 상태로 전환되면서 ⚠️ Reentrancy anomaly was detected. 에러가 발생했습니다.

관련 이벤트 스트림이 여럿 겹치는 문제로 인해 발생한 문제로 추정됩니다

✅ 최종 해결 방향
.notEnabled 상태로 전환 시 textField.resignFirstResponder() 를 호출하여 명시적으로 입력 상태를 종료합니다.

.editingDidEnd 이벤트에서는 verificationCode 필드에 한해 Observable.empty()를 반환하여 상태 충돌을 방지합니다.

4자리 인증 코드의 유효성 검증이 성공할 경우,

코드 입력 필드를 .notEnabled 상태로 전환하고,

이후 비밀번호 필드의 입력을 활성화합니다.

😕 남은 제약 사항
다른 텍스트 필드의 경우, 입력 종료 시 자동으로 .normal 상태로 돌아가지만,

인증 코드 필드의 경우 위 방식으로 인해 .normal 상태로 복귀하지 못하는 문제가 있습니다.

다만, 인증 코드는 입력 중 이탈 가능성이 낮다고 판단되며, 전체 개발 리소스 대비 현재 구조가 가장 합리적이라 판단하여 이와 같이 처리하였습니다.


<br>
