### PR TITLE
[refactor]: MyInfoView의 레이아웃 수정

### DIFF
--- a/EveryTip/Targets/EveryTipPresentation/Sources/MyInfo/MyInfoViewController.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/MyInfo/MyInfoViewController.swift
@@ -225,7 +225,8 @@ final class MyInfoViewController: BaseViewController {
     private func setupConstraints() {
         roundedBackgroundView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
-            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(view)
         }
         
         userImageView.snp.makeConstraints {


### PR DESCRIPTION
- 18.0 업데이트 이후로 생긴 탭 변경시 하단 배경 색 비춤에 따른 수정사항

## 이슈 번호: N/A

## PR 타입

- [ ] 기능 구현
- [x] 오류 수정
- [x] 리팩토링

<br>

### 작업 내용

> 구현 및 작업 내용을 작성합니다.

18.0업데이트 이후 탭 간 이동시 애니메이션과 함께 하단 BackGround색상이 비춰보이는 이슈에 따른 배경 뷰 레이아웃의 간단한 수정사항

<br>

### PR 체크리스트

- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항

> PR 리뷰 시 주의 깊게 보거나 유의해야 할 점들과 기타 사항을 작성합니다.

- 유의 사항 1
- 기타 사항 1

<br>
