### PR TITLE
[Feat] 앱 전반에서 사용 될 toast message 구현

### DIFF
--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/Coordinator.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/Coordinator.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol Coordinator: AnyObject {
+public protocol Coordinator: AnyObject, ToastDisplayable {
     var parentCoordinator: Coordinator? { get set }
     var childCoordinators: [Coordinator] { get set }
     var navigationController: UINavigationController { get set }

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/Coordinator.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/Coordinator.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol Coordinator: AnyObject, ToastDisplayable {
+public protocol Coordinator: AnyObject {
     var parentCoordinator: Coordinator? { get set }
     var childCoordinators: [Coordinator] { get set }
     var navigationController: UINavigationController { get set }

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/Protocol/ToastDisplayable.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/Protocol/ToastDisplayable.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public protocol ToastDisplayable {
-    func show(message: String)
+    func showToast(message: String)
 }
 
 public extension ToastDisplayable {
-    func show(message: String) {
+    func showToast(message: String) {
         ToastManager.shared.show(message: message)
     }
 }

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/Protocol/ToastDisplayable.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/Protocol/ToastDisplayable.swift
@@ -1,0 +1,19 @@
+//
+//  ToastDisplayable.swift
+//  EveryTipPresentation
+//
+//  Created by 김경록 on 4/16/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import Foundation
+
+public protocol ToastDisplayable {
+    func show(message: String)
+}
+
+public extension ToastDisplayable {
+    func show(message: String) {
+        ToastManager.shared.show(message: message)
+    }
+}

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/ToastManager.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/ToastManager.swift
@@ -1,0 +1,92 @@
+//
+//  ToastManager.swift
+//  EveryTipPresentation
+//
+//  Created by 김경록 on 4/16/25.
+//  Copyright © 2025 EveryTip. All rights reserved.
+//
+
+import UIKit
+
+import SnapKit
+
+final class ToastManager {
+    static let shared = ToastManager()
+    
+    private var isShowingToast = false
+    
+    private init() {}
+    
+    private let toastView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.56)
+        view.layer.cornerRadius = 10
+        view.clipsToBounds = true
+        view.alpha = 0
+        view.isUserInteractionEnabled = false
+        return view
+    }()
+    
+    private let toastLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = .et_pretendard(
+            style: .medium,
+            size: 14
+        )
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        return label
+    }()
+    
+    func show(message: String) {
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+              let window = windowScene.windows.first(where: { $0.isKeyWindow }),
+              !isShowingToast else {
+            return
+        }
+        
+        isShowingToast = true
+        
+        toastLabel.text = message
+        
+        if toastLabel.superview == nil {
+            toastView.addSubview(toastLabel)
+        }
+        if toastView.superview == nil {
+            window.addSubview(toastView)
+        }
+        
+        toastLabel.snp.remakeConstraints {
+            $0.top.bottom.equalToSuperview().inset(10)
+            $0.centerY.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(12)
+        }
+        
+        toastView.snp.remakeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalTo(window.safeAreaLayoutGuide.snp.bottom).offset(-80)
+            $0.leading.greaterThanOrEqualToSuperview().offset(40)
+            $0.trailing.lessThanOrEqualToSuperview().offset(-40)
+        }
+        
+        UIView.animate(
+            withDuration: 0.3,
+            animations: {
+                self.toastView.alpha = 1
+            }) { _ in
+                UIView.animate(
+                    withDuration: 0.3,
+                    delay: 1.6,
+                    options: [],
+                    animations: {
+                        self.toastView.alpha = 0
+                    }) { _ in
+                        self.toastView.removeFromSuperview()
+                        self.toastLabel.removeFromSuperview()
+                        self.isShowingToast = false
+                    }
+            }
+    }
+}

--- a/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/BaseViewController.swift
+++ b/EveryTip/Targets/EveryTipPresentation/Sources/Common/ViewComponents/BaseViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class BaseViewController: UIViewController {
+class BaseViewController: UIViewController, ToastDisplayable {
     /// 스와이프로 뒤로가기 활성화 여부
     var isInteractivePopGestureEnabled = false
     


### PR DESCRIPTION
## 이슈 번호: #42 

## PR 타입

- [x] 기능 구현
- [ ] 오류 수정
- [ ] 리팩토링

<br>

### 작업 내용

> 구현 및 작업 내용을 작성합니다.

앱 전반에서 사용되는 토스트 메세지를 구현했습니다.

https://github.com/user-attachments/assets/b2f1d635-1720-4818-ac6d-fe33468b4648


<br>

### PR 체크리스트

- [x] PR 제목과 태그 (Feat, Refactor, Fix...etc) 와 작업 내용 확인
- [x] 코딩 컨벤션 확인
- [x] PR 관련 내용만 작성했는가 확인

<br>

### PR 유의 및 기타 사항

> PR 리뷰 시 주의 깊게 보거나 유의해야 할 점들과 기타 사항을 작성합니다.

- `isShowingToast` 를 활용하여 토스트 메세지의 중복 노출을 방지했습니다. 그 과정에서 단일 인스턴스를 유지하길 바랐기때문에 싱글톤으로 정의했습니다.
(각기 다른 메세지가 무분별하게 띄워질 만일의 사태까지 고려)
- Reactor가 직접 View의 책임을 갖지 않도록 역할을 분리했습니다.
Toast 메시지는 Reactor의 상태 변화에 따라 노출되며, DIP를 적용하기 위해 `ToastDisplayable` 프로토콜을 도입했습니다.
해당 프로토콜을 기존 Coordinator가 채택함으로써, 모든 화면에서 일관된 방식으로 메시지를 노출할 수 있도록 설계했습니다.
- 토스트 메시지가 쓰이는 뷰는 한정적이지만 그것을 구분하여 특정 코디네이터에서만 채택하는것은 중요하지 않다고 생각하여 전체 coordinator에 적용시켰습니다.

